### PR TITLE
Clone error in closure to prevent compiler lifetime errors.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl EyreHandler for Handler {
             write!(f, "\n\nCaused by:")?;
 
             let multiple = cause.source().is_some();
-            let errors = std::iter::successors(Some(cause), |e| e.source());
+            let errors = std::iter::successors(Some(cause), |e| e.clone().source());
 
             for (n, error) in errors.enumerate() {
                 writeln!(f)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl EyreHandler for Handler {
             write!(f, "\n\nCaused by:")?;
 
             let multiple = cause.source().is_some();
-            let errors = std::iter::successors(Some(cause), |e| e.clone().source());
+            let errors = std::iter::successors(Some(cause), |e| (*e).source());
 
             for (n, error) in errors.enumerate() {
                 writeln!(f)?;


### PR DESCRIPTION
Presently, if you build `simple-eyre` from `crates.io`, you get the following compiler error:

```
william@xubuntu-dtrain:~/Projects/embedded/simple-eyre$ cargo build
    Updating crates.io index
   Compiling eyre v0.6.5
   Compiling indenter v0.3.3
   Compiling once_cell v1.7.2
   Compiling simple-eyre v0.3.0 (/home/william/Projects/embedded/simple-eyre)
error: lifetime may not live long enough
  --> src/lib.rs:86:65
   |
86 |             let errors = std::iter::successors(Some(cause), |e| e.source());
   |                                                              -- ^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
   |                                                              ||
   |                                                              |return type of closure is Option<&'2 dyn std::error::Error>
   |                                                              has type `&'1 &dyn std::error::Error`

error: aborting due to previous error

error: could not compile `simple-eyre`

To learn more, run the command again with --verbose.
```

I don't actually understand why `clone()` fixes this, but it does. I was test-driving `simple-eyre` to see if it fits my needs, and while it doesn't atm (plain `eyre` actually uses _less_ `.text` :o), I figured I should make a PR :).